### PR TITLE
cmake: Fix module path (analogous to simfil)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ if (WITH_COVERAGE AND NOT GCOVR_BIN)
   message(WARNING "Could not find gcovr binary. Disabling coverage report!")
 endif()
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake/cmake-modules")
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake-modules")
 
 ##############
 # deps


### PR DESCRIPTION
Same bug as in simfil, disables usage as submodule.