### PR TITLE
Allow accessing TileFeatureLayer features by index

### DIFF
--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -82,7 +82,7 @@ public:
     void setPrefix(KeyValuePairs const& prefix);
 
     /** Destructor for the TileFeatureLayer class. */
-    ~TileFeatureLayer();
+    ~TileFeatureLayer() override;
 
     /**
      * Creates a new feature and insert it into this tile layer.
@@ -123,7 +123,7 @@ public:
     struct Iterator
     {
         Iterator(TileFeatureLayer const& layer, size_t i) : layer_(layer), i_(i) {}
-        model_ptr<Feature> operator*() { return layer_.resolveFeature(*layer_.root(i_)); }
+        model_ptr<Feature> operator*() { return layer_.at(i_); }
         Iterator& operator++()
         {
             ++i_;
@@ -156,6 +156,12 @@ public:
 
    /** Convert to GeoJSON geometry collection. */
    nlohmann::json toGeoJson() const;
+
+   /** Access number of stored features */
+   size_t size() const;
+
+   /** Access feature at index i */
+   model_ptr<Feature> at(size_t i) const;
 
    /** Shared pointer type */
    using Ptr = std::shared_ptr<TileFeatureLayer>;

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -305,7 +305,7 @@ TileFeatureLayer::Iterator TileFeatureLayer::begin() const
 
 TileFeatureLayer::Iterator TileFeatureLayer::end() const
 {
-    return TileFeatureLayer::Iterator{*this, numRoots()};
+    return TileFeatureLayer::Iterator{*this, size()};
 }
 
 void TileFeatureLayer::write(std::ostream& outputStream)
@@ -325,6 +325,16 @@ nlohmann::json TileFeatureLayer::toGeoJson() const
         {"type", "FeatureCollection"},
         {"features", features},
     });
+}
+
+size_t TileFeatureLayer::size() const
+{
+    return numRoots();
+}
+
+model_ptr<Feature> TileFeatureLayer::at(size_t i) const
+{
+    return resolveFeature(*root(i));
 }
 
 }


### PR DESCRIPTION
This is needed so erdblick can resolve picked features - note that the iterator also uses the new methods, so they are getting tested via the iterator test.