### PR TITLE
Requests to unknown map+layer combinations receive a 400 response

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ void main(int argc, char const *argv[])
      HttpClient client("localhost", service.port());
 
      auto receivedTileCount = 0;
-     client.request(std::make_shared<Request>(
+     client.request(std::make_shared<LayerTilesRequest>(
          "Tropico",
          "WayLayer",
          std::vector<TileId>{{1234, 5678, 9112, 1234}},

--- a/README.md
+++ b/README.md
@@ -264,3 +264,16 @@ void main(int argc, char const *argv[])
 ```
 
 Keep in mind, that you can also run a `mapget` service without any RPCs in your application. Check out [`examples/cpp/local-datasource`](examples/cpp/local-datasource/main.cpp) on how to do that.
+
+### erdblick-mapget-datasource communication pattern
+
+TODO: expand and polish this section stub.
+
+1. Client (`erdblick` etc.) sends a composite list of requests to `mapget`. Requests are batched because browsers limit the number of concurrent requests to one domain, but we want to stream potentially hundreds of tiles.
+
+2. `mapget` checks if all requested map+layer combinations can be fulfilled with data sources
+   - yes: create tile requests, stream responses back to client,
+   - no: return 400 Bad Request (client needs to refresh its info on map availability).
+
+3. A data source drops offline / `mapget` request fails during processing?
+   - `cpp-httplib` cleanup callback returns timeout response (probably status code 408).

--- a/examples/cpp/local-datasource/main.cpp
+++ b/examples/cpp/local-datasource/main.cpp
@@ -76,13 +76,13 @@ int main(int argc, char** argv)
     service.add(std::make_shared<MyLocalDataSource>());
 
     // Create a request. The request will immediately start to be worked on.
-    service
-        .request(std::make_shared<LayerTilesRequest>(
+    auto r = std::make_shared<LayerTilesRequest>(
             "Tropico",
             "WayLayer",
             std::vector<TileId>{TileId(12345), TileId(67689)},
             [](auto&& result)
-            { log().info("Got {}", MapTileKey(*result).toString()); }))
-        ->wait();
+            { log().info("Got {}", MapTileKey(*result).toString()); });
+    service.request({r});
+    r->wait();
     return 0;
 }

--- a/examples/cpp/local-datasource/main.cpp
+++ b/examples/cpp/local-datasource/main.cpp
@@ -77,7 +77,7 @@ int main(int argc, char** argv)
 
     // Create a request. The request will immediately start to be worked on.
     service
-        .request(std::make_shared<Request>(
+        .request(std::make_shared<LayerTilesRequest>(
             "Tropico",
             "WayLayer",
             std::vector<TileId>{TileId(12345), TileId(67689)},

--- a/libs/http-datasource/include/mapget/http-datasource/datasource-server.h
+++ b/libs/http-datasource/include/mapget/http-datasource/datasource-server.h
@@ -24,11 +24,11 @@ public:
     ~DataSourceServer() override;
 
     /**
-     * Set the Callback which will be invoked when a `/tile`-request is received.
+     * Set the callback which will be invoked when a `/tile`-request is received.
      * The callback argument is a fresh TileFeatureLayer, which the callback
      * must fill according to the set TileFeatureLayer's layer info and tile id.
      * If an error occurs while filling the tile, the callback can use
-     * TileFeatureLayer::setError(...) to singal the error downstream.
+     * TileFeatureLayer::setError(...) to signal the error downstream.
      */
     DataSourceServer& onTileRequest(std::function<void(TileFeatureLayer::Ptr)> const&);
 

--- a/libs/http-datasource/src/datasource-server.cpp
+++ b/libs/http-datasource/src/datasource-server.cpp
@@ -44,6 +44,8 @@ void DataSourceServer::setup(httplib::Server& server)
     server.Get(
         "/tile",
         [this](const httplib::Request& req, httplib::Response& res) {
+
+            // Extract parameters from request.
             auto layerIdParam = req.get_param_value("layer");
             auto layer = impl_->info_.getLayer(layerIdParam);
 
@@ -57,6 +59,7 @@ void DataSourceServer::setup(httplib::Server& server)
             if (req.has_param("responseType"))
                 responseType = req.get_param_value("responseType");
 
+            // Create response TileFeatureLayer.
             auto tileFeatureLayer = std::make_shared<TileFeatureLayer>(
                 tileIdParam,
                 impl_->info_.nodeId_,
@@ -66,7 +69,7 @@ void DataSourceServer::setup(httplib::Server& server)
             if (impl_->tileCallback_)
                 impl_->tileCallback_(tileFeatureLayer);
 
-            // Serialize TileFeatureLayer using TileLayerStream
+            // Serialize TileFeatureLayer using TileLayerStream.
             if (responseType == "binary") {
                 std::stringstream content;
                 TileLayerStream::FieldOffsetMap fieldOffsets{

--- a/libs/http-service/include/mapget/http-service/http-client.h
+++ b/libs/http-service/include/mapget/http-service/http-client.h
@@ -28,7 +28,7 @@ public:
     /**
      * Post a Request for a number of tiles from a particular map layer.
      */
-    Request::Ptr request(Request::Ptr const& request);
+    LayerTilesRequest::Ptr request(LayerTilesRequest::Ptr const& request);
 
 private:
     struct Impl;

--- a/libs/http-service/include/mapget/http-service/http-client.h
+++ b/libs/http-service/include/mapget/http-service/http-client.h
@@ -7,7 +7,9 @@
 
 namespace mapget {
 
-/** Client class, which implements asynchronous fetching from a mapget HTTP service.*/
+/**
+ * Client class, which implements asynchronous fetching from a mapget HTTP service.
+ */
 class HttpClient
 {
 public:

--- a/libs/http-service/src/cli.cpp
+++ b/libs/http-service/src/cli.cpp
@@ -107,7 +107,7 @@ struct FetchCommand
         int port = std::stoi(server_.substr(delimiterPos+1, server_.size()));
 
         mapget::HttpClient cli(host, port);
-        auto request = std::make_shared<Request>(
+        auto request = std::make_shared<LayerTilesRequest>(
             map_, layer_, std::vector<TileId>{tiles_.begin(), tiles_.end()},
             [](auto&& tile){
                 if (log().level() == spdlog::level::trace) {

--- a/libs/http-service/src/http-client.cpp
+++ b/libs/http-service/src/http-client.cpp
@@ -75,6 +75,8 @@ LayerTilesRequest::Ptr HttpClient::request(const LayerTilesRequest::Ptr& request
         else if (tileResponse->status == 400) {
             request->setStatus(mapget::RequestStatus::NoDataSource);
         }
+        // TODO if multiple LayerTileRequests are ever sent by this client,
+        //  additionally handle RequestStatus::Aborted.
     }
 
     return request;

--- a/libs/http-service/src/http-client.cpp
+++ b/libs/http-service/src/http-client.cpp
@@ -28,7 +28,7 @@ struct HttpClient::Impl {
     {
         auto mapIt = sources_.find(std::string(map));
         if (mapIt == sources_.end())
-            throw logRuntimeError("Could nto find map data source info");
+            throw logRuntimeError("Could not find map data source info");
         return mapIt->second.getLayer(std::string(layer));
     }
 };

--- a/libs/http-service/src/http-client.cpp
+++ b/libs/http-service/src/http-client.cpp
@@ -70,7 +70,6 @@ LayerTilesRequest::Ptr HttpClient::request(const LayerTilesRequest::Ptr& request
     if (tileResponse) {
         if (tileResponse->status == 200) {
             reader->read(tileResponse->body);
-            request->setStatus(mapget::RequestStatus::Success);
         }
         else if (tileResponse->status == 400) {
             request->setStatus(mapget::RequestStatus::NoDataSource);

--- a/libs/http-service/src/http-client.cpp
+++ b/libs/http-service/src/http-client.cpp
@@ -45,7 +45,7 @@ std::vector<DataSourceInfo> HttpClient::sources() const
     return result;
 }
 
-Request::Ptr HttpClient::request(const Request::Ptr& request)
+LayerTilesRequest::Ptr HttpClient::request(const LayerTilesRequest::Ptr& request)
 {
     // TODO why is this at the beginning of the request function?
     // When is a request created as done?

--- a/libs/http-service/src/http-service.cpp
+++ b/libs/http-service/src/http-service.cpp
@@ -24,7 +24,7 @@ struct HttpService::Impl
 
         std::stringstream buffer_;
         std::string responseType_;
-        std::vector<Request::Ptr> requests_;
+        std::vector<LayerTilesRequest::Ptr> requests_;
         TileLayerStream::FieldOffsetMap fieldsOffsets_;
 
         void parseRequestFromJson(nlohmann::json const& requestJson)
@@ -36,7 +36,7 @@ struct HttpService::Impl
             for (auto const& tid : requestJson["tileIds"].get<std::vector<uint64_t>>())
                 tileIds.emplace_back(tid);
             requests_.push_back(
-                std::make_shared<Request>(mapId, layerId, std::move(tileIds), nullptr));
+                std::make_shared<LayerTilesRequest>(mapId, layerId, std::move(tileIds), nullptr));
         }
 
         void setResponseType(std::string const& s)

--- a/libs/http-service/src/http-service.cpp
+++ b/libs/http-service/src/http-service.cpp
@@ -13,7 +13,7 @@ struct HttpService::Impl
     explicit Impl(HttpService& self) : self_(self) {}
 
     // Use a shared buffer for the responses and a mutex for thread safety.
-    struct TileLayerRequestState
+    struct HttpTilesRequestState
     {
         static constexpr auto binaryMimeType = "application/binary";
         static constexpr auto jsonlMimeType = "application/jsonl";
@@ -42,11 +42,11 @@ struct HttpService::Impl
         void setResponseType(std::string const& s)
         {
             responseType_ = s;
-            if (responseType_ == TileLayerRequestState::binaryMimeType)
+            if (responseType_ == HttpTilesRequestState::binaryMimeType)
                 return;
-            if (responseType_ == TileLayerRequestState::jsonlMimeType)
+            if (responseType_ == HttpTilesRequestState::jsonlMimeType)
                 return;
-            if (responseType_ == TileLayerRequestState::anyMimeType) {
+            if (responseType_ == HttpTilesRequestState::anyMimeType) {
                 responseType_ = binaryMimeType;
                 return;
             }
@@ -81,7 +81,7 @@ struct HttpService::Impl
         nlohmann::json j = nlohmann::json::parse(req.body);
         auto requestsJson = j["requests"];
         // TODO: Limit number of requests to avoid DoS to other users.
-        auto state = std::make_shared<TileLayerRequestState>();
+        auto state = std::make_shared<HttpTilesRequestState>();
         bool canProcessAllRequests = true;
         for (auto& requestJson : requestsJson) {
             std::string mapId = requestJson["mapId"];

--- a/libs/model/include/mapget/model/layer.h
+++ b/libs/model/include/mapget/model/layer.h
@@ -153,6 +153,7 @@ protected:
     std::string nodeId_;
     std::string mapId_;
     std::shared_ptr<LayerInfo> layerInfo_;
+    // TODO what is the error string for? Does it follow some standard?
     std::optional<std::string> error_;
     std::chrono::time_point<std::chrono::system_clock> timestamp_;
     std::optional<std::chrono::milliseconds> ttl_;

--- a/libs/model/src/info.cpp
+++ b/libs/model/src/info.cpp
@@ -214,7 +214,7 @@ std::shared_ptr<LayerInfo> DataSourceInfo::getLayer(std::string const& layerId) 
     auto it = layers_.find(layerId);
     if (it == layers_.end()) {
         throw logRuntimeError(
-            stx::format("Could not find info for layer '{}'/'{}'", mapId_, layerId)
+            stx::format("Could not find layer '{}' in map '{}'", layerId, mapId_)
         );
     }
     return it->second;

--- a/libs/pymapget/binding/py-client.h
+++ b/libs/pymapget/binding/py-client.h
@@ -73,7 +73,8 @@ public:
 
     TileFeatureLayer::Ptr next() {
         std::unique_lock lock(bufferMutex_);
-        bufferSignal_.wait(lock, [this](){ return !buffer_.empty() || isDone(); });
+        bufferSignal_.wait(lock, [this](){ return !buffer_.empty() ||
+                                 this->getStatus() != RequestStatus::Open; });
         if (buffer_.empty()) {
             throw py::stop_iteration();
         } else {

--- a/libs/pymapget/binding/py-client.h
+++ b/libs/pymapget/binding/py-client.h
@@ -60,15 +60,16 @@ namespace mapget
 
 namespace py = pybind11;
 
-class PyRequest : public Request {
+class PyRequest : public LayerTilesRequest
+{
 public:
-    using Request::Request;
+    using LayerTilesRequest::LayerTilesRequest;
 
     void notifyResult(TileFeatureLayer::Ptr result) override {
         std::unique_lock lock(bufferMutex_);
         buffer_.push(result);
         bufferSignal_.notify_one();  // Signal that a new result is available
-        Request::notifyResult(result);
+        LayerTilesRequest::notifyResult(result);
     }
 
     TileFeatureLayer::Ptr next() {

--- a/libs/service/include/mapget/service/datasource.h
+++ b/libs/service/include/mapget/service/datasource.h
@@ -28,7 +28,7 @@ public:
      * times in parallel to satisfy data requests for a mapget Service.
      * @param featureTile A TileFeatureLayer object which this data source
      *  should fill according the available data. If any error occurs
-     *  while dong so, the data source may use TileLayer::setError.
+     *  while doing so, the data source may use TileLayer::setError.
      *  To store any extra information of interest such as timings or sizes,
      *  TileLayer::setInfo() may be used.
      */

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -21,16 +21,16 @@ enum RequestStatus {
  * a map layer id, an array of tile ids, and a callback function
  * which signals results.
  */
-class Request
+class LayerTilesRequest
 {
     friend class Service;
     friend class HttpClient;
 
 public:
-    using Ptr = std::shared_ptr<Request>;
+    using Ptr = std::shared_ptr<LayerTilesRequest>;
 
     /** Construct a request with the relevant parameters. */
-    Request(
+    LayerTilesRequest(
         std::string mapId,
         std::string layerId,
         std::vector<TileId> tiles,
@@ -125,13 +125,13 @@ public:
      *  to one service. Otherwise, there is undefined behavior.
      * @return The `r` parameter value is returned.
      */
-    Request::Ptr request(Request::Ptr r);
+    LayerTilesRequest::Ptr request(LayerTilesRequest::Ptr r);
 
     /**
      * Abort the given request. The request will be removed from
      * the processing queue, and forcefully marked as done.
      */
-    void abort(Request::Ptr const& r);
+    void abort(LayerTilesRequest::Ptr const& r);
 
     /** DataSourceInfo for all data sources which have been added to this Service. */
     std::vector<DataSourceInfo> info();

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -142,7 +142,7 @@ public:
     std::vector<DataSourceInfo> info();
 
     /** Checks if a DataSource can serve the requested map+layer combination. */
-    bool canProcess(std::string const& mapId, std::string const& layerId);
+    bool hasLayer(std::string const& mapId, std::string const& layerId);
 
     /** Get the Cache which this service was constructed with. */
     [[nodiscard]] Cache::Ptr cache();

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -12,8 +12,9 @@ namespace mapget
 
 enum RequestStatus {
     Open = 0x0,
-    Done = 0x1, /** The request has been fully satisfied. */
-    NoDataSource = 0x2 /** No data source could provide the requested map + layer. */
+    Success = 0x1, /** The request has been fully satisfied. */
+    NoDataSource = 0x2, /** No data source could provide the requested map + layer. */
+    Aborted = 0x3 /** Canceled, e.g. because a bundled request cannot be fulfilled. */
 };
 
 /**
@@ -41,6 +42,9 @@ public:
 
     /** Wait for the request to be done. */
     void wait();
+
+    /** Check whether the request is done or still running. */
+    bool isDone();
 
     /** The map id for which this request is dedicated. */
     std::string mapId_;
@@ -119,13 +123,14 @@ public:
     void remove(DataSource::Ptr const& dataSource);
 
     /**
-     * Request some map data tiles. Will throw an exception if
-     * there is no worker which is able to process the request.
-     * Note: The same request object should only ever be passed
-     *  to one service. Otherwise, there is undefined behavior.
-     * @return The `r` parameter value is returned.
+     * Request some map data tiles. If the requested map+layer
+     * combination is available, will schedule a job to retrieve
+     * the tiles. A request object should only ever be passed
+     * to one service. Otherwise, there is undefined behavior.
+     * @return false if the requested map+layer is not available
+     * from any connected DataSource, true otherwise.
      */
-    LayerTilesRequest::Ptr request(LayerTilesRequest::Ptr r);
+    bool request(std::vector<LayerTilesRequest::Ptr> requests);
 
     /**
      * Abort the given request. The request will be removed from

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -44,7 +44,7 @@ public:
 
     /**
      * The map tile ids for which this request is dedicated.
-     * Must not be empty. Result tiles will be processed in the given order
+     * Must not be empty. Result tiles will be processed in the given order.
      */
     std::vector<TileId> tiles_;
 
@@ -70,7 +70,7 @@ protected:
     // So the requester can track how many results have been received.
     size_t resultCount_ = 0;
 
-    // Mutex/Condition variable for done-signal
+    // Mutex/condition variable for done-signal.
     std::mutex doneMutex_;
     std::condition_variable doneConditionVariable_;
 };

--- a/libs/service/include/mapget/service/service.h
+++ b/libs/service/include/mapget/service/service.h
@@ -66,7 +66,7 @@ public:
     /**
      * The callback function which is called when all tiles have been processed.
      */
-    std::function<void()> onDone_;
+    std::function<void(RequestStatus)> onDone_;
 
 protected:
     virtual void notifyResult(TileFeatureLayer::Ptr);

--- a/libs/service/src/service.cpp
+++ b/libs/service/src/service.cpp
@@ -366,7 +366,7 @@ bool Service::request(std::vector<LayerTilesRequest::Ptr> requests)
 {
     bool dataSourcesAvailable = true;
     for (const auto& r : requests) {
-        if (!canProcess(r->mapId_, r->layerId_)) {
+        if (!hasLayer(r->mapId_, r->layerId_)) {
             dataSourcesAvailable = false;
             r->setStatus(RequestStatus::NoDataSource);
         }
@@ -400,7 +400,7 @@ Cache::Ptr Service::cache()
     return impl_->cache_;
 }
 
-bool Service::canProcess(std::string const& mapId, std::string const& layerId)
+bool Service::hasLayer(std::string const& mapId, std::string const& layerId)
 {
     std::unique_lock lock(impl_->jobsMutex_);
     // Check that one of the data sources can fulfill the request.

--- a/test/integration/CMakeLists.txt
+++ b/test/integration/CMakeLists.txt
@@ -100,3 +100,5 @@ add_wheel_test(test-config-py
     # Request from cpp datasource
     -f "python -m mapget --config ${CMAKE_CURRENT_LIST_DIR}/../../examples/config/sample-first-datasource.toml fetch"
 )
+
+# TODO should there be a Python test for the 400 response?

--- a/test/unit/test-http-datasource.cpp
+++ b/test/unit/test-http-datasource.cpp
@@ -129,21 +129,24 @@ TEST_CASE("HttpDataSource", "[HttpDataSource]")
         {
             mapget::HttpClient client("localhost", service.port());
 
+            auto receivedTileCount = 0;
             auto unknownMapRequest = std::make_shared<mapget::LayerTilesRequest>(
                 "UnknownMap",
                 "WayLayer",
                 std::vector<mapget::TileId>{{1234}},
-                [&](auto&& tile) { /* TODO check something? */ });
+                [&](auto&& tile) { receivedTileCount++; });
             client.request(unknownMapRequest)->wait();
             REQUIRE(unknownMapRequest->getStatus() == mapget::RequestStatus::NoDataSource);
+            REQUIRE(receivedTileCount == 0);
 
             auto unknownLayerRequest = std::make_shared<mapget::LayerTilesRequest>(
                 "Tropico",
                 "UnknownLayer",
                 std::vector<mapget::TileId>{{1234}},
-                [&](auto&& tile) { /* TODO check something? */ });
+                [&](auto&& tile) { receivedTileCount++; });
             client.request(unknownLayerRequest)->wait();
             REQUIRE(unknownLayerRequest->getStatus() == mapget::RequestStatus::NoDataSource);
+            REQUIRE(receivedTileCount == 0);
         }
 
         service.stop();

--- a/test/unit/test-http-datasource.cpp
+++ b/test/unit/test-http-datasource.cpp
@@ -113,7 +113,7 @@ TEST_CASE("HttpDataSource", "[HttpDataSource]")
             mapget::HttpClient client("localhost", service.port());
 
             auto receivedTileCount = 0;
-            client.request(std::make_shared<mapget::Request>(
+            client.request(std::make_shared<mapget::LayerTilesRequest>(
                                "Tropico",
                                "WayLayer",
                                std::vector<mapget::TileId>{{1234, 5678, 9112, 1234}},
@@ -129,7 +129,7 @@ TEST_CASE("HttpDataSource", "[HttpDataSource]")
         {
             mapget::HttpClient client("localhost", service.port());
 
-            auto unknownMapRequest = std::make_shared<mapget::Request>(
+            auto unknownMapRequest = std::make_shared<mapget::LayerTilesRequest>(
                 "UnknownMap",
                 "WayLayer",
                 std::vector<mapget::TileId>{{1234}},
@@ -137,7 +137,7 @@ TEST_CASE("HttpDataSource", "[HttpDataSource]")
             client.request(unknownMapRequest)->wait();
             REQUIRE(unknownMapRequest->getStatus() == mapget::RequestStatus::NoDataSource);
 
-            auto unknownLayerRequest = std::make_shared<mapget::Request>(
+            auto unknownLayerRequest = std::make_shared<mapget::LayerTilesRequest>(
                 "Tropico",
                 "UnknownLayer",
                 std::vector<mapget::TileId>{{1234}},

--- a/test/unit/test-http-service.cpp
+++ b/test/unit/test-http-service.cpp
@@ -1,0 +1,1 @@
+// TODO maybe move the 2 last test cases from test-http-datasource here?

--- a/test/unit/test-http-service.cpp
+++ b/test/unit/test-http-service.cpp
@@ -1,1 +1,0 @@
-// TODO maybe move the 2 last test cases from test-http-datasource here?


### PR DESCRIPTION
Extends mapget service by the `canProcess()` function and adds a status field to the mapget request class, with one option being `NoDataSource`.
 
HTTP client-service setup communicates the `NoDataSource` status via a 400 code response.

Adds two test cases for unknown map and unknown layer ID. 

Closes #20 