### PR TITLE
ID parts validation

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -76,7 +76,7 @@ jobs:
         if: matrix.os == 'windows-latest'
         working-directory: build
         run: |
-          choco install --no-progress -y openssl
+          choco install --no-progress -y openssl --version=1.1.1.2100
           echo "cmake -DPython3_ROOT_DIR=$env:pythonLocation"
           cmake "-DPython3_ROOT_DIR=$env:pythonLocation" -DPython3_FIND_REGISTRY=LAST -DHTTPLIB_USE_ZLIB_IF_AVAILABLE=OFF -DCMAKE_BUILD_TYPE=Release ..
           cmake --build . --config Release

--- a/examples/cpp/http-datasource/main.cpp
+++ b/examples/cpp/http-datasource/main.cpp
@@ -32,7 +32,7 @@ public:
     void fill(TileFeatureLayer::Ptr const& tile)
     {
         // Add some ID parts that are shared by all features in the tile.
-        tile->setPrefix({{"areadId", "BestArea"}});
+        tile->setPrefix({{"areaId", "BestArea"}});
 
         // Create a feature with line geometry
         auto feature1 = tile->newFeature("Way", {{"wayId", 42}});

--- a/examples/cpp/local-datasource/main.cpp
+++ b/examples/cpp/local-datasource/main.cpp
@@ -41,7 +41,7 @@ public:
 
     void fill(TileFeatureLayer::Ptr const& tile) override {
         // Add some ID parts that are shared by all features in the tile.
-        tile->setPrefix({{"areadId", "BestArea"}});
+        tile->setPrefix({{"areaId", "BestArea"}});
 
         // Create a feature with line geometry
         auto feature1 = tile->newFeature("Way", {{"wayId", 42}});

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -115,12 +115,12 @@ public:
      * The order of values in KeyValuePairs must be the same as in the composition!
      * @param typeId Feature type id, throws error if the type was not registered.
      * @param featureIdParts Uniquely identifying information for the feature.
-     * @param excludeTilePrefix False if featureIdParts includes prefix components.
+     * @param includeTilePrefix True if the id should be evaluated with this tile's prefix prepended.
      */
     bool validFeatureId(
         const std::string_view& typeId,
         KeyValuePairs const& featureIdParts,
-        bool excludeTilePrefix);
+        bool includeTilePrefix);
 
     /**
      * Create a new named attribute, which may be inserted into an attribute layer.

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -89,10 +89,11 @@ public:
      * Creates a new feature and insert it into this tile layer.
      * The featureIdParts (which do not include the featureIdPrefix of the layer)
      * must conform to an existing UniqueIdComposition for the feature typeId
-     * within the associated layer, or a rutime error will be raised.
+     * within the associated layer, or a runtime error will be raised.
      * @param typeId Specifies the type of the feature.
      * @param featureIdParts Uniquely identifying information for the feature,
-     * according to the requirements of typeId. If empty, an error will be thrown.
+     * according to the requirements of typeId. Do not include the tile feature
+     * prefix. If empty, an error will be thrown.
      */
     model_ptr<Feature> newFeature(
         std::string_view const& typeId,

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -87,12 +87,12 @@ public:
 
     /**
      * Creates a new feature and insert it into this tile layer.
-     * The unique identifying information, prepended with the featureIdPrefix,
+     * The featureIdParts (which do not include the featureIdPrefix of the layer)
      * must conform to an existing UniqueIdComposition for the feature typeId
-     * within the associated layer.
+     * within the associated layer, or a rutime error will be raised.
      * @param typeId Specifies the type of the feature.
      * @param featureIdParts Uniquely identifying information for the feature,
-     * according to the requirements of typeId.
+     * according to the requirements of typeId. Must not be empty.
      */
     model_ptr<Feature> newFeature(
         std::string_view const& typeId,

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -92,7 +92,7 @@ public:
      * within the associated layer, or a rutime error will be raised.
      * @param typeId Specifies the type of the feature.
      * @param featureIdParts Uniquely identifying information for the feature,
-     * according to the requirements of typeId. Must not be empty.
+     * according to the requirements of typeId. If empty, an error will be thrown.
      */
     model_ptr<Feature> newFeature(
         std::string_view const& typeId,
@@ -103,14 +103,18 @@ public:
      * feature. The created feature id will not use the common feature id prefix from
      * this tile feature layer, since the reference may be to a feature stored in a
      * different tile.
-     * TODO bool parameter to specify whether to add the feature id prefix?
      */
     model_ptr<FeatureId> newFeatureId(
         std::string_view const& typeId,
         KeyValuePairs const& featureIdParts);
 
     /**
-     * TODO description.
+     * Validate that a unique id composition exists that matches this feature id,
+     * The field values must match the limitations of the IdPartDataType.
+     * Used by newFeatureId to check featureIdParts before creation.
+     * @param typeId Specifies the type of the feature.
+     * @param featureIdParts Uniquely identifying information for the feature.
+     * @param excludeTilePrefix False if featureIdParts includes prefix components.
      */
     bool validFeatureId(
         FeatureTypeInfo const& typeId,

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -111,8 +111,8 @@ public:
 
     /**
      * Validate that a unique id composition exists that matches this feature id,
-     * The field values must match the limitations of the IdPartDataType.
-     * Used by newFeatureId to check featureIdParts before creation.
+     * The field values must match the limitations of the IdPartDataType, and
+     * The order of values in KeyValuePairs must be the same as in the composition!
      * @param typeId Feature type id, throws error if the type was not registered.
      * @param featureIdParts Uniquely identifying information for the feature.
      * @param excludeTilePrefix False if featureIdParts includes prefix components.

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -103,6 +103,7 @@ public:
      * feature. The created feature id will not use the common feature id prefix from
      * this tile feature layer, since the reference may be to a feature stored in a
      * different tile.
+     * TODO bool parameter to specify whether to add the feature id prefix?
      */
     model_ptr<FeatureId> newFeatureId(
         std::string_view const& typeId,
@@ -114,7 +115,7 @@ public:
     bool validFeatureId(
         FeatureTypeInfo const& typeId,
         KeyValuePairs const& featureIdParts,
-        bool includeTilePrefix);
+        bool excludeTilePrefix);
 
     /**
      * Create a new named attribute, which may be inserted into an attribute layer.

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -50,6 +50,7 @@ public:
      *  Each feature in this layer must have a feature type which is also present in
      *  the layer. Therefore, feature ids from this layer can be verified to conform
      *  to one of the allowed feature id compositions for the allowed type.
+     * TODO "for the allowed type" -> "for the feature type" ?
      * @param fields Shared field name dictionary, which allows compressed storage
      *  of object field name strings. It is auto-filled, and one instance may be used
      *  by multiple TileFeatureLayer instances.
@@ -101,6 +102,7 @@ public:
      * Create a new feature id. Use this function to create a reference to another
      * feature. The created feature id will not use the common feature id prefix from
      * this tile feature layer.
+     * TODO what is the common feature id prefix? Why is this skipped here?
      */
     model_ptr<FeatureId> newFeatureId(
         std::string_view const& typeId,

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -112,12 +112,12 @@ public:
      * Validate that a unique id composition exists that matches this feature id,
      * The field values must match the limitations of the IdPartDataType.
      * Used by newFeatureId to check featureIdParts before creation.
-     * @param typeId Specifies the type of the feature.
+     * @param typeId Feature type id, throws error if the type was not registered.
      * @param featureIdParts Uniquely identifying information for the feature.
      * @param excludeTilePrefix False if featureIdParts includes prefix components.
      */
     bool validFeatureId(
-        FeatureTypeInfo const& typeId,
+        const std::string_view& typeId,
         KeyValuePairs const& featureIdParts,
         bool excludeTilePrefix);
 

--- a/libs/model/include/mapget/model/featurelayer.h
+++ b/libs/model/include/mapget/model/featurelayer.h
@@ -101,12 +101,20 @@ public:
     /**
      * Create a new feature id. Use this function to create a reference to another
      * feature. The created feature id will not use the common feature id prefix from
-     * this tile feature layer.
-     * TODO what is the common feature id prefix? Why is this skipped here?
+     * this tile feature layer, since the reference may be to a feature stored in a
+     * different tile.
      */
     model_ptr<FeatureId> newFeatureId(
         std::string_view const& typeId,
         KeyValuePairs const& featureIdParts);
+
+    /**
+     * TODO description.
+     */
+    bool validFeatureId(
+        FeatureTypeInfo const& typeId,
+        KeyValuePairs const& featureIdParts,
+        bool includeTilePrefix);
 
     /**
      * Create a new named attribute, which may be inserted into an attribute layer.

--- a/libs/model/include/mapget/model/info.h
+++ b/libs/model/include/mapget/model/info.h
@@ -67,28 +67,29 @@ NLOHMANN_JSON_SERIALIZE_ENUM(
         {LayerType::GLTF, "GLTF"},
     })
 
-/** Structure to represent a part of a unique feature id composition. */
-struct UniqueIdPart
+/** Structure to represent a part of a feature id composition. */
+struct IdPart
 {
-    /** Unique identifier part */
-    std::string partId_;
+    /** Label/identifier for this ID part.
+     * Unique under all ID parts of a feature. */
+    std::string idPartLabel_;
 
-    /** Description of the unique identifier */
+    /** Description of the identifier. */
     std::string description_;
 
-    /** Datatype of the unique identifier */
+    /** Data type of the identifier. */
     IdPartDataType datatype_;
 
     /** Is the identifier synthetic or part of a map specification? */
     bool isSynthetic_ = false;
 
-    /** Is the identifier actually optional? */
+    /** Is the identifier optional in feature queries? */
     bool isOptional_ = false;
 
-    /** Create UniqueIdPart from JSON. */
-    static UniqueIdPart fromJson(const nlohmann::json& j);
+    /** Create IdPart from JSON. */
+    static IdPart fromJson(const nlohmann::json& j);
 
-    /** Serialize UniqueIdPart to JSON. */
+    /** Serialize IdPart to JSON. */
     [[nodiscard]] nlohmann::json toJson() const;
 };
 
@@ -102,7 +103,7 @@ struct FeatureTypeInfo
      * List of allowed unique id compositions (each id composition is a list of id parts)
      * A single id composition must never have more than 16 parts.
      */
-    std::vector<std::vector<UniqueIdPart>> uniqueIdCompositions_;
+    std::vector<std::vector<IdPart>> uniqueIdCompositions_;
 
     /**
      * Deserializes a FeatureTypeInfo object from JSON.

--- a/libs/model/include/mapget/model/info.h
+++ b/libs/model/include/mapget/model/info.h
@@ -11,13 +11,12 @@ namespace mapget
 {
 
 /**
- * Version Definition - This is used to recognize whether
- * a stored blob of a TileFeatureLayer should be parsed by this
- * version of the mapget library. When a TileFeatureLayer is serialized,
- * the current Version value for the map layer and and the stream protocol are
- * also stored. Upon deserialization, the Major-Minor version values
- * must match the parsed version Major-Minor value, for both the for the map layer
- * and and the stream protocol.
+ * Version Definition - This is used to recognize whether a stored blob of a
+ * TileFeatureLayer should be parsed by this version of the mapget library.
+ * When a TileFeatureLayer is serialized, the current Version value for the
+ * map layer and the stream protocol are also stored. Upon deserialization,
+ * the Major-Minor version values must match the parsed version Major-Minor
+ * values, for both the map layer and the stream protocol.
  */
 struct Version {
     uint16_t major_ = 0;
@@ -118,6 +117,7 @@ struct FeatureTypeInfo
      *         "partId": <string>,          // Mandatory: The ID of the unique ID part.
      *         "description": <string>,     // Optional: The description of the unique ID part.
      *         "datatype": <IdPartDataType>,// Optional: The data type of the unique ID part, must be one of the enum values from IdPartDataType. Defaults to I64.
+     *         TODO why "datatype"  and not "dataType" to match other fields?
      *         "isSynthetic": <bool>,       // Optional: A flag indicating if the unique ID part is synthetic. Defaults to false.
      *         "isOptional": <bool>         // Optional: A flag indicating if the unique ID part is optional. Defaults to false.
      *       },

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -87,7 +87,12 @@ simfil::shared_model_ptr<Feature> TileFeatureLayer::newFeature(
     const std::string_view& typeId,
     const KeyValuePairs& featureIdParts)
 {
-    // TODO: Validate ID parts
+    // TODO: Validate ID parts.
+    // For the feature type requested, retrieve possible uniqueIdCompositions.
+    // Then go through the list and check that keys in the provided feature ID
+    // parts match one of the uniqueIdComposition specs?
+    // And that the values in KeyValuePairs have the right type?
+    // Must the order of values in KeyValuePairs match the composition order?
     auto featureIdIndex = impl_->featureIds_.size();
     auto featureIdObject = newObject(featureIdParts.size());
     impl_->featureIds_.emplace_back(FeatureId::Data{

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -167,7 +167,7 @@ bool idPartsMatchComposition(
 bool TileFeatureLayer::validFeatureId(
     const std::string_view& typeId,
     KeyValuePairs const& featureIdParts,
-    bool excludeTilePrefix) {
+    bool includeTilePrefix) {
 
     auto typesIterator = this->layerInfo_->featureTypes_.begin();
     while (typesIterator != this->layerInfo_->featureTypes_.end()) {
@@ -182,7 +182,7 @@ bool TileFeatureLayer::validFeatureId(
 
     for (auto& candidateComposition : typesIterator->uniqueIdCompositions_) {
         uint32_t compositionMatchStartIndex = 0;
-        if (excludeTilePrefix && this->featureIdPrefix().has_value()) {
+        if (includeTilePrefix && this->featureIdPrefix().has_value()) {
             // Iterate past the prefix in the unique id composition.
             compositionMatchStartIndex = this->featureIdPrefix().value()->size();
         }
@@ -251,7 +251,7 @@ TileFeatureLayer::newFeatureId(
     const std::string_view& typeId,
     const KeyValuePairs& featureIdParts)
 {
-    if (!validFeatureId(typeId, featureIdParts, true)) {
+    if (!validFeatureId(typeId, featureIdParts, false)) {
         throw logRuntimeError("Could not find a matching ID composition.");
     }
 

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -86,7 +86,8 @@ TileFeatureLayer::~TileFeatureLayer() = default;
 namespace
 {
 
-/* Check that starting from a given index, the parts of an id composition
+/**
+ * Check that starting from a given index, the parts of an id composition
  * match the featureIdParts segment from start for the given length.
  */
 bool idPartsMatchComposition(
@@ -163,10 +164,6 @@ bool idPartsMatchComposition(
 
 }  // namespace
 
-/*
- * Checks if featureIdParts match one of the uniqueIdComposition specifications.
- * The order of values in KeyValuePairs must be the same as in the composition!
- */
 bool TileFeatureLayer::validFeatureId(
     const std::string_view& typeId,
     KeyValuePairs const& featureIdParts,

--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -95,7 +95,7 @@ bool TileFeatureLayer::validFeatureId(
     for (auto& candidateComposition : typeId.uniqueIdCompositions_) {
         auto compositionPart = candidateComposition.begin();
 
-        if (this->featureIdPrefix().has_value() && excludeTilePrefix) {
+        if (excludeTilePrefix && this->featureIdPrefix().has_value()) {
 
             // Iterate past the prefix in the unique id composition.
             auto featureIdPrefixSize = this->featureIdPrefix().value()->size();

--- a/libs/model/src/info.cpp
+++ b/libs/model/src/info.cpp
@@ -71,7 +71,7 @@ nlohmann::json Version::toJson() const
     return nlohmann::json{{"major", major_}, {"minor", minor_}, {"patch", patch_}};
 }
 
-UniqueIdPart UniqueIdPart::fromJson(const nlohmann::json& j)
+IdPart IdPart::fromJson(const nlohmann::json& j)
 {
     try {
         return {
@@ -86,10 +86,10 @@ UniqueIdPart UniqueIdPart::fromJson(const nlohmann::json& j)
     }
 }
 
-nlohmann::json UniqueIdPart::toJson() const
+nlohmann::json IdPart::toJson() const
 {
     return nlohmann::json{
-        {"partId", partId_},
+        {"partId", idPartLabel_},
         {"description", description_},
         {"datatype", datatype_},
         {"isSynthetic", isSynthetic_},
@@ -99,11 +99,11 @@ nlohmann::json UniqueIdPart::toJson() const
 FeatureTypeInfo FeatureTypeInfo::fromJson(const nlohmann::json& j)
 {
     try {
-        std::vector<std::vector<UniqueIdPart>> idCompositions;
+        std::vector<std::vector<IdPart>> idCompositions;
         for (auto& item : j.at("uniqueIdCompositions")) {
-            std::vector<UniqueIdPart> idParts;
+            std::vector<IdPart> idParts;
             for (auto& idPart : item) {
-                idParts.push_back(UniqueIdPart::fromJson(idPart));
+                idParts.push_back(IdPart::fromJson(idPart));
             }
             idCompositions.push_back(idParts);
         }

--- a/test/unit/test-model.cpp
+++ b/test/unit/test-model.cpp
@@ -93,6 +93,11 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
         "Tropico",
         layerInfo,
         fieldNames);
+
+    // Test creating a feature while tile prefix is not set
+    auto feature0 = tile->newFeature("Way", {{"areaId", "MediocreArea"}, {"wayId", 24}});
+
+    // Set the tile feature id prefix
     tile->setPrefix({{"areaId", "TheBestArea"}});
 
     // Create a feature with line geometry
@@ -265,9 +270,9 @@ TEST_CASE("FeatureLayer", "[test.featurelayer]")
         REQUIRE(readTiles.size() == 3);
         REQUIRE(readTiles[0]->fieldNames() == readTiles[1]->fieldNames());
         REQUIRE(readTiles[1]->fieldNames() == readTiles[2]->fieldNames());
-        REQUIRE(readTiles[0]->numRoots() == 3);
-        REQUIRE(readTiles[1]->numRoots() == 3);
-        REQUIRE(readTiles[2]->numRoots() == 4);
+        REQUIRE(readTiles[0]->numRoots() == 4);
+        REQUIRE(readTiles[1]->numRoots() == 4);
+        REQUIRE(readTiles[2]->numRoots() == 5);
     }
 }
 


### PR DESCRIPTION
When creating a feature ID, mapget now checks that the parts match one of the predefined ID composites + data passed for the ID parts fits the defined type.

Extended the FeatureLayer test to cover new functionality.

Closes #18.