### PR TITLE
Fixed infinite loop.

### DIFF
--- a/libs/model/src/featurelayer.cpp
+++ b/libs/model/src/featurelayer.cpp
@@ -169,18 +169,17 @@ bool TileFeatureLayer::validFeatureId(
     KeyValuePairs const& featureIdParts,
     bool includeTilePrefix) {
 
-    auto typesIterator = this->layerInfo_->featureTypes_.begin();
-    while (typesIterator != this->layerInfo_->featureTypes_.end()) {
-        auto& type = *typesIterator;
-        if (type.name_ == typeId) {
+    auto typeIt = this->layerInfo_->featureTypes_.begin();
+    while (typeIt != this->layerInfo_->featureTypes_.end()) {
+        if (typeIt->name_ == typeId)
             break;
-        }
+        ++typeIt;
     }
-    if (typesIterator == this->layerInfo_->featureTypes_.end()) {
+    if (typeIt == this->layerInfo_->featureTypes_.end()) {
         throw logRuntimeError(stx::format("Could not find feature type {}", typeId));
     }
 
-    for (auto& candidateComposition : typesIterator->uniqueIdCompositions_) {
+    for (auto& candidateComposition : typeIt->uniqueIdCompositions_) {
         uint32_t compositionMatchStartIndex = 0;
         if (includeTilePrefix && this->featureIdPrefix().has_value()) {
             // Iterate past the prefix in the unique id composition.


### PR DESCRIPTION
C++ compilers are mysterious. The infinite loop that existed here was only active in debug mode. In release mode, the function always just picked the first type and never even entered the loop.